### PR TITLE
add flushStartingWith() and allStartingWith() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $blink->flush(); // Empty the entire blink
 
 $blink->flushStartingWith('somekey'); // Remove all items whose keys start with "somekey"
 
-$blink->increment('number'); // $blink->get('key') will return 1 
+$blink->increment('number'); // $blink->get('key') will return 1
 $blink->increment('number'); // $blink->get('key') will return 2
 $blink->increment('number', 3); // $blink->get('key') will return 5
 
@@ -96,7 +96,7 @@ You can call the following methods on it:
  *
  * @param string|array $name
  * @param string|int|null $value
- * 
+ *
  * @return $this
  */
 public function put($name, $value = null)
@@ -133,9 +133,9 @@ public function has(string $name) : bool
 ```php
 /**
  * Only if the given key is not present in the blink cache the callable will be executed.
- * 
+ *
  * The result of the callable will be stored in the given key and returned.
- * 
+ *
  * @param $key
  * @param callable $callable
  *
@@ -149,6 +149,18 @@ public function has(string $name) : bool
  * Get all values in the blink cache.
 */
 public function all() : array
+```
+
+### allStartingWith
+```php
+/**
+ * Get all values from the blink cache which keys start with the given string.
+ *
+ * @param string $startingWith
+ *
+ * @return array
+*/
+public function allStartingWith(string $startingWith = '') : array
 ```
 
 ### forget
@@ -175,6 +187,18 @@ public function forget(string $key)
  public function flush()
 ```
 
+### flushStartingWith
+```php
+/**
+ * Flush all values from the blink cache which keys start with the specified value.
+ *
+ * @param string $startingWith
+ *
+ * @return $this
+ */
+ public function flushStartingWith(string $startingWith)
+```
+
 ### pull
 ```php
 /**
@@ -182,7 +206,7 @@ public function forget(string $key)
  *
  * This function has support for the '*' wildcard.
  *
- * @param string $name 
+ * @param string $name
  *
  * @return null|string
  */

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -79,6 +79,24 @@ class Blink implements ArrayAccess, Countable
     }
 
     /**
+     * Get all keys starting with a given string from the store.
+     *
+     * @param string $startingWith
+     *
+     * @return array
+     */
+    public function allStartingWith(string $startingWith = '') : array
+    {
+        $values = $this->all();
+
+        if ($startingWith === '') {
+            return $values;
+        }
+
+        return $this->filterKeysStartingWith($values, $startingWith);
+    }
+
+    /**
      * Forget a value from the store.
      *
      * This function has support for the '*' wildcard.
@@ -108,6 +126,26 @@ class Blink implements ArrayAccess, Countable
     public function flush()
     {
         return $this->values = [];
+    }
+
+    /**
+     * Flush all values from the store which keys start with a given string.
+     *
+     * @param string $startingWith
+     *
+     * @return $this
+     */
+    public function flushStartingWith(string $startingWith = '')
+    {
+        $newContent = [];
+
+        if ($startingWith !== '') {
+            $newContent = $this->filterKeysNotStartingWith($this->all(), $startingWith);
+        }
+
+        $this->values = $newContent;
+
+        return $this;
     }
 
     /**

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -197,6 +197,47 @@ class BlinkTest extends TestCase
     }
 
     /** @test */
+    public function it_can_fetch_all_values_starting_with_a_certain_value()
+    {
+        $this->blink->put([
+            'group1Key1' => 'valueGroup1Key1',
+            'group1Key2' => 'valueGroup1Key2',
+            'testgroup1' => 'valueTestGroup1',
+            'group2Key1' => 'valueGroup2Key1',
+            'group2Key2' => 'valueGroup2Key2',
+        ]);
+
+        $expectedArray = [
+            'group1Key1' => 'valueGroup1Key1',
+            'group1Key2' => 'valueGroup1Key2',
+        ];
+
+        $this->assertSame($expectedArray, $this->blink->allStartingWith('group1'));
+    }
+
+    /** @test */
+    public function it_can_fetch_all_values_starting_with_a_default_value()
+    {
+        $this->blink->put([
+            'group1Key1' => 'valueGroup1Key1',
+            'group1Key2' => 'valueGroup1Key2',
+            'testgroup1' => 'valueTestGroup1',
+            'group2Key1' => 'valueGroup2Key1',
+            'group2Key2' => 'valueGroup2Key2',
+        ]);
+
+        $expectedArray = [
+            'group1Key1' => 'valueGroup1Key1',
+            'group1Key2' => 'valueGroup1Key2',
+            'testgroup1' => 'valueTestGroup1',
+            'group2Key1' => 'valueGroup2Key1',
+            'group2Key2' => 'valueGroup2Key2',
+        ];
+
+        $this->assertSame($expectedArray, $this->blink->allStartingWith());
+    }
+
+    /** @test */
     public function it_can_forget_a_value()
     {
         $this->blink->put('key', 'value');
@@ -240,6 +281,27 @@ class BlinkTest extends TestCase
         $this->assertNull($this->blink->get('key'));
 
         $this->assertNull($this->blink->get('otherKey'));
+    }
+
+    /** @test */
+    public function it_can_flush_all_keys_starting_with_a_certain_string()
+    {
+        $this->blink->put([
+            'group1' => 'valueGroup1',
+            'group1Key1' => 'valueGroup1Key1',
+            'group1Key2' => 'valueGroup1Key2',
+            'group2Key1' => 'valueGroup2Key1',
+            'group2Key2' => 'valueGroup2Key2',
+        ]);
+
+        $this->blink->flushStartingWith('group1');
+
+        $expectedArray = [
+            'group2Key1' => 'valueGroup2Key1',
+            'group2Key2' => 'valueGroup2Key2',
+        ];
+
+        $this->assertSame($expectedArray, $this->blink->all());
     }
 
     /** @test */


### PR DESCRIPTION
This PR:

- adds missing `flushStartingWith()` method.
- adds `allStartingWith()` method (same behaviour as that from `spatie/valuestore`)
- adds tests covering such new methods (by doing that, Blink has now 100% test coverage)
- updates README.md