### PR TITLE
Add support for PHP 8 and PHPUnit 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 7.3, 7.2, 7.1, 7.0]
+                php: [8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `blink` will be documented in this file
 ## 1.1.3 - 2020-11-29
 
 - support PHP 8.0 and PHPUnit 9
-- now requires PHP 7.1 and up
+- now requires PHP 7.3 and up
 
 ## 1.1.2 - 2019-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `blink` will be documented in this file
 
+## 1.1.3 - 2020-11-29
+
+- support PHP 8.0 and PHPUnit 9
+- now requires PHP 7.1 and up
+
 ## 1.1.2 - 2019-02-16
 
 - support numeric keys (#19)

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -13,7 +13,7 @@ class BlinkTest extends TestCase
     /** @var \Spatie\Blink\Blink */
     protected $blink;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR is in response to issue #24 and includes the following:
- Updating supported PHP to 7.3 and up and PHP 8.0
- Updating supported PHPUnit to version 9.0
- Updating unit tests with required changes for PHPUnit