### PR TITLE
Fix the global method to return always the same instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ $blink->put('key', 'value');
 count($blink); // Returns 1
 ```
 
+If you want to use the same instance within the current request, you can use the static method `global`.
+
+```php
+Blink::global()->put('key', 'value');
+
+Blink::global()->get('key') // Returns 'value';
+```
+
 Read the [usage](#usage) section of this readme to learn the other methods.
 
 ## Support us

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you want to use the same instance within the current request, you can use the
 ```php
 Blink::global()->put('key', 'value');
 
-Blink::global()->get('key') // Returns 'value';
+Blink::global()->get('key') // Returns 'value'
 ```
 
 Read the [usage](#usage) section of this readme to learn the other methods.

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -8,29 +8,33 @@ use Countable;
 class Blink implements ArrayAccess, Countable
 {
     /** @var array */
-    protected static $static_values = [];
-
-    /** @var array */
     protected $values;
 
     /**
-     * Instantiate a new Blink instance that shares the same values as all other Blink instances created via
-     * `Blink::global`
+     * @var null|Blink
+     */
+    private static $instance;
+
+    /**
+     * Get always the same instance within the current request
      *
-     * @example
-     * function a() { return Blink::global()->once('random', $expensiveFunction); }
-     * function b() { return Blink::global()->once('random', $expensiveFunction); }
-     * a(); b(); // call to function `b` will return cached value stored in function `a`
      * @return static
      */
-    public static function global()
+    public static function global(): self
     {
-        return new static(static::$static_values);
+        if (!self::$instance) {
+            self::$instance = new static();
+        }
+
+        return self::$instance;
     }
 
-    public function __construct($stored_values = [])
+    /**
+     * @param array $values
+     */
+    public function __construct(array $values = [])
     {
-        $this->values = $stored_values;
+        $this->values = $values;
     }
 
     /**
@@ -77,7 +81,7 @@ class Blink implements ArrayAccess, Countable
             : $default;
     }
 
-    /*
+    /**
      * Determine if the store has a value for the given name.
      *
      * This function has support for the '*' wildcard.

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -13,7 +13,7 @@ class Blink implements ArrayAccess, Countable
     /**
      * @var null|Blink
      */
-    private static $instance;
+    protected static $instance;
 
     /**
      * Get always the same instance within the current request

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -499,4 +499,12 @@ class BlinkTest extends TestCase
         $this->assertSame(4, $this->blink->onceIf(false, 'key', $callable));
         $this->assertSame(2, $this->blink->onceIf(true, 'key', $callable));
     }
+
+    /** @test */
+    public function it_can_use_global_instance()
+    {
+        Blink::global()->put('key', 'value');
+
+        $this->assertSame('value', Blink::global()->get('key'));
+    }
 }


### PR DESCRIPTION
This PR fixes the global method to return always the same instance during the current request. I also added a test to prove it and tried to explain in the readme how it works.