### PR TITLE
add __callStatic handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `blink` will be documented in this file
 
+
+### What's Changed
+
+- Add static calls that redirect to the global instance, i.e. Blink::get, etc.
+
 ## 1.4.0 - 2023-07-19
 
 ### What's Changed

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -30,6 +30,18 @@ class Blink implements ArrayAccess, Countable
     }
 
     /**
+     * Handle dynamic static method calls via the global instance
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        return static::global()->$method(...$parameters);
+    }
+
+    /**
      * @param array $values
      */
     public function __construct(array $values = [])


### PR DESCRIPTION
Now you can write:

```
Blink::set()
```

Instead of

```
Blink::global()->set()
```

I should have thought of it earlier.